### PR TITLE
Pmo is added to `docker-compose.yml`

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,8 @@ services:
       - pgdata:/var/lib/postgresql/data
     ports:
       - '5432:5432'
+    networks:
+      - pmo
   keycloak:
     image: quay.io/keycloak/keycloak:23.0.2
     container_name: keycloak
@@ -21,13 +23,31 @@ services:
       KEYCLOAK_ADMIN: admin
       KEYCLOAK_ADMIN_PASSWORD: password
     ports:
-      - '8090:8080'
+      - '8090:8090'
+    networks:
+      - pmo
     depends_on:
       - db
-    command: start-dev --import-realm
+    command: start-dev --import-realm --http-port=8090
     volumes:
       - ./realm-export.json:/opt/keycloak/data/import/realm-export.json
+  app:
+    container_name: tracehub-pmo
+    build: .
+    ports:
+      - '8080:8080'
+    depends_on:
+      - db
+      - keycloak
+    networks:
+      - pmo
+    env_file:
+      - ./.env
 
 volumes:
   pgdata:
     driver: local
+
+networks:
+  pmo:
+    driver: bridge


### PR DESCRIPTION
Closes #40 

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of this PR:
This PR focuses on adding a new network named "pmo" to the docker-compose.yml file and making necessary changes to the keycloak and app services.

### Detailed summary:
- Added a new network named "pmo" to the docker-compose.yml file.
- Updated the keycloak service to use the "pmo" network.
- Updated the keycloak service to use port 8090 instead of 8080.
- Updated the keycloak service command to include the "--http-port=8090" flag.
- Added a new "app" service to the docker-compose.yml file.
- Configured the "app" service to use the "pmo" network.
- Configured the "app" service to use port 8080.
- Added "depends_on" for the "app" service to ensure it starts after the "db" and "keycloak" services.
- Added "env_file" for the "app" service to load environment variables from the .env file.
- Updated the volumes configuration for the "pgdata" volume.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->