### PR TITLE
Swagger host added to configurations

### DIFF
--- a/realm-export.json
+++ b/realm-export.json
@@ -347,6 +347,14 @@
           "clientRole": true,
           "containerId": "8bc708b1-5b38-4a86-a9cc-af834e0d6784",
           "attributes": {}
+        },
+        {
+          "id": "ba83e807-b5e9-48b2-beee-346d45fffda2",
+          "name": "uma_protection",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "8bc708b1-5b38-4a86-a9cc-af834e0d6784",
+          "attributes": {}
         }
       ],
       "admin-cli": [],
@@ -521,6 +529,31 @@
   "webAuthnPolicyPasswordlessAvoidSameAuthenticatorRegister": false,
   "webAuthnPolicyPasswordlessAcceptableAaguids": [],
   "webAuthnPolicyPasswordlessExtraOrigins": [],
+  "users": [
+    {
+      "id": "bda20d8d-c916-4dd9-92c7-6748cfc511ac",
+      "createdTimestamp": 1709286021048,
+      "username": "service-account-tracehub-pmo",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "serviceAccountClientId": "tracehub-pmo",
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "default-roles-pmo"
+      ],
+      "clientRoles": {
+        "tracehub-pmo": [
+          "uma_protection"
+        ]
+      },
+      "notBefore": 0,
+      "groups": [
+        "/broker"
+      ]
+    }
+  ],
   "scopeMappings": [
     {
       "clientScope": "broker",
@@ -851,7 +884,8 @@
         "*"
       ],
       "webOrigins": [
-        "http://localhost:8080"
+        "http://locahost:8080",
+        "*"
       ],
       "notBefore": 0,
       "bearerOnly": false,
@@ -859,22 +893,76 @@
       "standardFlowEnabled": true,
       "implicitFlowEnabled": false,
       "directAccessGrantsEnabled": true,
-      "serviceAccountsEnabled": false,
+      "serviceAccountsEnabled": true,
+      "authorizationServicesEnabled": true,
       "publicClient": false,
       "frontchannelLogout": true,
       "protocol": "openid-connect",
       "attributes": {
-        "oidc.ciba.grant.enabled": "false",
         "client.secret.creation.time": "1705571311",
-        "backchannel.logout.session.required": "true",
         "post.logout.redirect.uris": "+",
-        "oauth2.device.authorization.grant.enabled": "false",
+        "oauth2.device.authorization.grant.enabled": "true",
+        "backchannel.logout.revoke.offline.tokens": "false",
+        "use.refresh.tokens": "true",
+        "oidc.ciba.grant.enabled": "false",
+        "backchannel.logout.session.required": "true",
+        "client_credentials.use_refresh_token": "false",
+        "tls.client.certificate.bound.access.tokens": "false",
+        "require.pushed.authorization.requests": "false",
+        "acr.loa.map": "{}",
         "display.on.consent.screen": "false",
-        "backchannel.logout.revoke.offline.tokens": "false"
+        "token.response.type.bearer.lower-case": "false"
       },
       "authenticationFlowBindingOverrides": {},
       "fullScopeAllowed": true,
       "nodeReRegistrationTimeout": -1,
+      "protocolMappers": [
+        {
+          "id": "71bd2ecd-87aa-4702-83f4-ad932771cf01",
+          "name": "Client IP Address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientAddress",
+            "introspection.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientAddress",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "081d164c-79ac-4066-97c0-cabf29f9b9aa",
+          "name": "Client ID",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "client_id",
+            "introspection.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "client_id",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "3d4613a3-d582-4867-8c8f-8c903883cde4",
+          "name": "Client Host",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientHost",
+            "introspection.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientHost",
+            "jsonType.label": "String"
+          }
+        }
+      ],
       "defaultClientScopes": [
         "web-origins",
         "acr",
@@ -888,7 +976,50 @@
         "phone",
         "offline_access",
         "microprofile-jwt"
-      ]
+      ],
+      "authorizationSettings": {
+        "allowRemoteResourceManagement": true,
+        "policyEnforcementMode": "ENFORCING",
+        "resources": [
+          {
+            "name": "Default Resource",
+            "type": "urn:tracehub-pmo:resources:default",
+            "ownerManagedAccess": false,
+            "attributes": {},
+            "_id": "9493b68d-795d-4b82-b7b3-32fabfc9240c",
+            "uris": [
+              "/*"
+            ]
+          }
+        ],
+        "policies": [
+          {
+            "id": "6194f1f2-ca91-47bb-93d8-ab921b4cde00",
+            "name": "Default Policy",
+            "description": "A policy that grants access only for users within this realm",
+            "type": "js",
+            "logic": "POSITIVE",
+            "decisionStrategy": "AFFIRMATIVE",
+            "config": {
+              "code": "// by default, grants any permission associated with this policy\n$evaluation.grant();\n"
+            }
+          },
+          {
+            "id": "925e0765-c149-48a2-835e-8ace11621682",
+            "name": "Default Permission",
+            "description": "A permission that applies to the default resource type",
+            "type": "resource",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "defaultResourceType": "urn:tracehub-pmo:resources:default",
+              "applyPolicies": "[\"Default Policy\"]"
+            }
+          }
+        ],
+        "scopes": [],
+        "decisionStrategy": "UNANIMOUS"
+      }
     }
   ],
   "clientScopes": [
@@ -1516,7 +1647,7 @@
   ],
   "identityProviderMappers": [
     {
-      "id": "f4175660-fec2-4438-85c3-b8e98583b129",
+      "id": "d07522c3-3586-4262-9e6e-5143722d029a",
       "name": "read-token",
       "identityProviderAlias": "github",
       "identityProviderMapper": "github-user-attribute-mapper",
@@ -1527,7 +1658,7 @@
       }
     },
     {
-      "id": "a98d2b6a-c98b-4223-be0f-3af541f6c514",
+      "id": "01359399-5e5e-4ba3-87bf-5cac5c6be9bd",
       "name": "Github role",
       "identityProviderAlias": "github",
       "identityProviderMapper": "oidc-hardcoded-role-idp-mapper",
@@ -1614,14 +1745,14 @@
         "subComponents": {},
         "config": {
           "allowed-protocol-mapper-types": [
-            "oidc-usermodel-property-mapper",
-            "saml-user-property-mapper",
-            "oidc-full-name-mapper",
-            "oidc-address-mapper",
-            "saml-user-attribute-mapper",
             "saml-role-list-mapper",
+            "oidc-full-name-mapper",
+            "oidc-usermodel-attribute-mapper",
+            "saml-user-attribute-mapper",
             "oidc-sha256-pairwise-sub-mapper",
-            "oidc-usermodel-attribute-mapper"
+            "saml-user-property-mapper",
+            "oidc-address-mapper",
+            "oidc-usermodel-property-mapper"
           ]
         }
       },
@@ -1633,14 +1764,14 @@
         "subComponents": {},
         "config": {
           "allowed-protocol-mapper-types": [
-            "oidc-full-name-mapper",
-            "oidc-address-mapper",
             "saml-user-attribute-mapper",
+            "oidc-address-mapper",
+            "oidc-sha256-pairwise-sub-mapper",
             "saml-user-property-mapper",
             "saml-role-list-mapper",
             "oidc-usermodel-attribute-mapper",
-            "oidc-usermodel-property-mapper",
-            "oidc-sha256-pairwise-sub-mapper"
+            "oidc-full-name-mapper",
+            "oidc-usermodel-property-mapper"
           ]
         }
       }


### PR DESCRIPTION
@h1alexbel take a look, please
Closes #67 

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to enhance the Keycloak realm configuration by adding a new user, enabling service accounts, and configuring authorization settings.

### Detailed summary
- Added a new user `service-account-tracehub-pmo` with associated roles and groups
- Enabled service accounts and authorization services
- Added protocol mappers for client IP address, client ID, and client host
- Configured authorization settings for resource management and policies

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->